### PR TITLE
Fix z.warning behaviour and messages

### DIFF
--- a/R/cmultRepl.R
+++ b/R/cmultRepl.R
@@ -1,55 +1,76 @@
-cmultRepl <- function(X,label=0,method=c("GBM","SQ","BL","CZM","user"),output=c("prop", "p-counts"),
-                      frac=0.65,threshold=0.5,adjust=TRUE,t=NULL,s=NULL,z.warning=0.8,
-                      z.delete=TRUE,suppress.print=FALSE,delta=NULL)
-{
+cmultRepl <- function(X, label= 0, method= c("GBM","SQ","BL","CZM","user"),
+                      output= c("prop","p-counts"),
+                      frac= 0.65, threshold= 0.5, adjust= TRUE, 
+                      t= NULL, s= NULL, z.warning= 0.9, z.delete= TRUE,
+                      suppress.print= FALSE, delta= NULL) {
   
   if (any(X<0, na.rm=T)) stop("X contains negative values")
   if (is.vector(X) | is.character(X) | (nrow(X)==1)) stop("X must be a data matrix")
-  if (!is.na(label)){
+  if (!is.na(label)) {
     if (!any(X==label,na.rm=T)) stop(paste("Label",label,"was not found in the data set"))
     if (label!=0 & any(X==0,na.rm=T)) stop("Zero values not labelled as count zeros were found in the data set")
     if (any(is.na(X))) stop(paste("NA values not labelled as count zeros were found in the data set"))
   }
-  if (is.na(label)){
+  
+  if (is.na(label)) {
     if (any(X==0,na.rm=T)) stop("Zero values not labelled as count zeros were found in the data set")
     if (!any(is.na(X),na.rm=T)) stop(paste("Label",label,"was not found in the data set"))
   }
 
-  if (!missing("delta")){
+  if (!missing("delta")) {
     warning("The delta argument is deprecated, use frac instead: frac has been set equal to delta.")
     frac <- delta
   }
   
-  X <- as.data.frame(X,stringsAsFactors=TRUE)
+  X <- as.data.frame(X, stringsAsFactors=TRUE)
+  
   X[X==label] <- NA
   
-  checkNumZerosCol <- apply(X,2,function(x) sum(is.na(x)))
-  if (any(checkNumZerosCol/nrow(X) >= z.warning)) {
-    cases <- which(checkNumZerosCol/nrow(X) >= z.warning)
-    if (z.delete == TRUE){
-      if (length(cases) > (ncol(X)-2)) {stop(paste("More than 2 columns contain >",z.warning*100,"% zeros/unobserved values (see arguments z.warning and z.delete).",sep=""))}
-      X <- X[,-cases]
+  checkNumZerosCol <- apply(X, 2, function(x) sum(is.na(x)))
+  
+  if (any(checkNumZerosCol/nrow(X) > z.warning)) {    
+    cases <- which(checkNumZerosCol/nrow(X) > z.warning)    
+    if (z.delete == TRUE) {
+      if (length(cases) > (ncol(X)-2)) {
+        stop(paste("Almost all columns contain >", z.warning*100,
+                   "% zeros/unobserved values (see arguments z.warning and z.delete).",
+                   sep=""))
+      }      
+      X <- X[,-cases]      
       action <- "deleted"
-      warning(paste("Column no. ",cases," containing >",z.warning*100,"% zeros/unobserved values ",action," (see arguments z.warning and z.delete).\n",sep=""))
-    }
-    else{
-      action <- "found"
-      stop(paste("Column no. ",cases," containing >",z.warning*100,"% zeros/unobserved values ",action," (see arguments z.warning and z.delete. Check out with zPatterns()).\n",sep=""))
+      
+      warning(paste("Column no. ",cases," containing >", z.warning*100,
+                    "% zeros/unobserved values ", action, " (see arguments z.warning and z.delete).\n",
+                    sep=""))
+    } else {      
+      action <- "found"      
+      warning(paste("Column no. ",cases," containing >", z.warning*100,
+                    "% zeros/unobserved values ", action, " (see arguments z.warning and z.delete. Check out with zPatterns()).\n",
+                    sep=""))      
     }
   }
   
-  checkNumZerosRow <- apply(X,1,function(x) sum(is.na(x)))
-  if (any(checkNumZerosRow/ncol(X) >= z.warning)) {
-    cases <- which(checkNumZerosRow/ncol(X) >= z.warning)
-    if (z.delete == TRUE){
-      if (length(cases) > (nrow(X)-2)) {stop(paste("More than 2 rows contain >",z.warning*100,"% zeros/unobserved values (see arguments z.warning and z.delete).",sep=""))}
-      X <- X[,-cases]
+  checkNumZerosRow <- apply(X, 1, function(x) sum(is.na(x)))  
+  if (any(checkNumZerosRow/ncol(X) > z.warning)) {    
+    cases <- which(checkNumZerosRow/ncol(X) > z.warning)    
+    if (z.delete == TRUE) {
+      if (length(cases) > (nrow(X)-2)) {
+        stop(paste("Almost all rows contain >", z.warning*100,
+                   "% zeros/unobserved values (see arguments z.warning and z.delete).",
+                   sep=""))
+        }
+      X <- X[-cases,]      
       action <- "deleted"
-      warning(paste("Column no. ",cases," containing >",z.warning*100,"% zeros/unobserved values ",action," (see arguments z.warning and z.delete).\n",sep=""))
-    }
-    else{
-      action <- "found"
-      stop(paste("Column no. ",cases," containing >",z.warning*100,"% zeros/unobserved values ",action," (see arguments z.warning and z.delete. Check out with zPatterns()).\n",sep=""))
+      
+      warning(paste("Row no. ",cases," containing >", z.warning*100,
+                    "% zeros/unobserved values ", action, " (see arguments z.warning and z.delete).\n",
+                    sep=""))
+    } else {      
+      action <- "found"      
+      warning(paste("Row no. ", cases," containing >", z.warning*100,
+                    "% zeros/unobserved values ", action,
+                    " (see arguments z.warning and z.delete. Check out with zPatterns()).\n",
+                    sep=""))      
     }
   }
   


### PR DESCRIPTION
Dear @Japal 
Thank you for developing zCompositions package and sharing its source code.

I seem to have found a couple of issues after the last commit. Mainly, the code for detecting zeros in rows was using columns and I also changed the error message for a warning when z.delete is set to FALSE, as otherwise the function stops without computing the results.

I added some extra spaces for a longer format, but that is just aesthethic.

I hope you find these proposed changes useful.